### PR TITLE
BZIP2 fixed to avoid type errors when declarations are enforced; plus a read-byte fix

### DIFF
--- a/bzip2.lisp
+++ b/bzip2.lisp
@@ -429,9 +429,9 @@
              (bzip2-block-crc32 (state)
                (declare (type bzip2-state state))
                (let ((crc32-hi (ensure-and-read-bits 16 state))
-		     (crc32-lo (ensure-and-read-bits 16 state)))
+                     (crc32-lo (ensure-and-read-bits 16 state)))
                  (setf (bzip2-state-stored-block-crc state)
-		       (logior (ash crc32-hi 16) crc32-lo))
+                       (logior (ash crc32-hi 16) crc32-lo))
                  (transition-to bzip2-block-randombit)))
 
              (bzip2-block-randombit (state)
@@ -821,12 +821,12 @@
                       ((bzip2-state-block-randomized-p state)
                        (error 'bzip2-randomized-blocks-unimplemented))
                       (t
-		       ;; BZIP2-STATE-T-POSITION was sometimes set to
-		       ;; a value outside its declared domain. Now
-		       ;; TEMP is used to store this value instead.
-		       (let ((temp (aref tt (bzip2-state-t-position state))))
-			 (setf (bzip2-state-k0 state) (logand #xff temp)
-			       (bzip2-state-t-position state) (ash temp -8)))
+                       ;; BZIP2-STATE-T-POSITION was sometimes set to
+                       ;; a value outside its declared domain. Now
+                       ;; TEMP is used to store this value instead.
+                       (let ((temp (aref tt (bzip2-state-t-position state))))
+                         (setf (bzip2-state-k0 state) (logand #xff temp)
+                               (bzip2-state-t-position state) (ash temp -8)))
                        (incf (bzip2-state-n-blocks-used state))))
                     ;; We're not 'returning' anything here, we're just
                     ;; forcing this call to be in tail position.

--- a/stream.lisp
+++ b/stream.lisp
@@ -158,23 +158,23 @@
 
 (defun read-and-decompress-byte (stream)
   (flet ((maybe-done ()
-	   (when (output-available-p stream)
-	     (return-from read-and-decompress-byte
-	       (aref (output-buffer stream)
-		     (prog1 (output-buffer-index stream)
-		       (incf (output-buffer-index stream))))))))
+           (when (output-available-p stream)
+             (return-from read-and-decompress-byte
+               (aref (output-buffer stream)
+                     (prog1 (output-buffer-index stream)
+                       (incf (output-buffer-index stream))))))))
     ;; several input buffers may be used up before output is available
     ;; => read-byte should refill "something" while at all possible,
     ;; like read-sequence already does.
     (loop initially (maybe-done)
-	  do (refill-stream-output-buffer stream)
-	     (maybe-done)
-	     (unless (input-available-p stream)
-	       (refill-stream-input-buffer stream))
-	     ;; If we didn't refill, then we must be all done.
-	     (unless (input-available-p stream)
-	       (finish-dstate (dstate stream))
-	       (return :eof)))))
+          do (refill-stream-output-buffer stream)
+             (maybe-done)
+             (unless (input-available-p stream)
+               (refill-stream-input-buffer stream))
+             ;; If we didn't refill, then we must be all done.
+             (unless (input-available-p stream)
+               (finish-dstate (dstate stream))
+               (return :eof)))))
 
 (defun copy-existing-output (stream seq start end)
   (declare (type simple-octet-vector seq))


### PR DESCRIPTION
%BZIP2-STATE-MACHINE sometimes violated type declarations in runtime (SBCL makes it very visible, because its declarations are assertions).

Also, STREAM-READ-BYTE gave up too early when one input refill didn't entail successfull input refill. Reimplemented similarly to STREAM-READ-SEQUENCE, which worked perfectly.
